### PR TITLE
fix webview html content (not working on vsc-insider on electron 3.1.8)

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -234,7 +234,7 @@ const WebviewPanel = context => {
 		{preserveFocus: true, viewColumn: vscode.ViewColumn.One},
 		{enableScripts: true, retainContextWhenHidden: true}
 	)
-	panel.webview.html = fs.readFileSync(vscode.Uri.file(path.join(context.extensionPath, 'index.html')).fsPath)
+	panel.webview.html = fs.readFileSync(vscode.Uri.file(path.join(context.extensionPath, 'index.html')).fsPath, 'utf-8')
 	return {
 		dispose: () => panel.dispose()
 	}


### PR DESCRIPTION
extension works on vsc

Version: 1.33.1 (user setup)
Commit: 51b0b28134d51361cf996d2f0a1c698247aeabd8
Date: 2019-04-11T08:27:14.102Z
Electron: 3.1.6
Chrome: 66.0.3359.181
Node.js: 10.2.0
V8: 6.6.346.32
OS: Windows_NT x64 10.0.17134

But it is not working on vsc-insider 

Tested Version:
Version: 1.34.0-insider (user setup)
Commit: 6d5feae57959287fb116467f4eb6c7079571b466
Date: 2019-04-17T09:25:49.535Z
Electron: 3.1.8
Chrome: 66.0.3359.181
Node.js: 10.2.0
V8: 6.6.346.32
OS: Windows_NT x64 10.0.17134

According to VSCode API, [Webview.html](https://code.visualstudio.com/api/references/vscode-api#Webview) is a string. `readFileAsync` returns a Buffer if encoding is not set. Tested on vsc, set webview.html to a Buffer is working but it does not work on vsc-insider. I guess it may be relevant to the electron upgrade.