### PR TITLE
refactor: replace legacy url API

### DIFF
--- a/request.js
+++ b/request.js
@@ -1,8 +1,14 @@
 const http = require('http')
 const https = require('https')
 const crypto = require('crypto')
-const parse = require('url').parse
+const URL = require('url').URL
 const querystring = require('querystring')
+
+URL.prototype.resolve = function(relative){
+	return new URL(relative, this).toString();
+}
+
+const parse = (url) => new URL(url)
 
 let user = {}
 
@@ -14,7 +20,7 @@ const encrypt = object => {
 
 const request = (method, url, headers, body = null) =>
 	new Promise((resolve, reject) => {
-		(url.startsWith('https://') ? https : http).request(Object.assign(parse(url), { method, headers }))
+		(url.startsWith('https://') ? https : http).request(parse(url), { method, headers })
 		.on('response', response => resolve([201, 301, 302, 303, 307, 308].includes(response.statusCode) ? request(method, parse(url).resolve(response.headers.location), headers, body) : response))
 		.on('error', error => reject(error)).end(body)
 	})

--- a/runtime.js
+++ b/runtime.js
@@ -422,7 +422,13 @@ const DuplexChannel = context => {
 }
 
 const AssistServer = context => {
-	const urlParse = require('url').parse
+	const URL = require('url').URL
+	Object.defineProperty(URL.prototype, 'query', {
+		get: function query(){
+			return this.searchParams.toString()
+		}
+	})
+	const urlParse = (url) => new URL(url, url.startsWith('/')?'relative://':'')
 	const queryify = require('querystring').stringify
 	const queryParse = require('querystring').parse
 


### PR DESCRIPTION
## 描述
将旧的URL API替换为WHATWG URL API
## 原因
根据Nodejs.org上的文档，旧的URL API在Node.js v11.0.0版本被弃用，直到v15.13.0才被撤销弃用，改为Legacy。<sup>[[1]](https://nodejs.org/dist/latest-v15.x/docs/api/url.html#url_legacy_url_api)</sup>
我Windows上的VS Code版本号为v1.55.0，其Node.js版本号为v12.18.3；
我Deepin v20.1上的VS Code版本号为v.1.51.0，其Node.js版本号为v12.14.1，均适用本次修改。
## 新的问题
URL类不支持直接解析纯相对路径(即只提供“/song/:id")，我在runtime.js中只做了临时处理。😅
是不是要先开个issue讨论？😀